### PR TITLE
feat: add migration for source datatype

### DIFF
--- a/prisma/migrations/20250324090735_change_datatype_of_source/migration.sql
+++ b/prisma/migrations/20250324090735_change_datatype_of_source/migration.sql
@@ -1,0 +1,12 @@
+/*
+  Warnings:
+
+  - Changed the type of `source` on the `tbl_sources` table. No cast exists, the column would be dropped and recreated, which cannot be done if there is data, since the column is required.
+
+*/
+-- AlterTable
+ALTER TABLE "tbl_sources" DROP COLUMN "source",
+ADD COLUMN     "source" "DataSource" NOT NULL;
+
+-- CreateIndex
+CREATE UNIQUE INDEX "tbl_sources_source_riverBasin_key" ON "tbl_sources"("source", "riverBasin");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -44,7 +44,7 @@ enum SettingDataType {
 model Source {
   id   Int    @id @default(autoincrement())
   uuid String @unique @default(uuid())
-  source String 
+  source DataSource
   riverBasin String
   createdAt DateTime  @default(now())
   updatedAt DateTime? @updatedAt()


### PR DESCRIPTION
added missing migrations for `source` column in Source table 