### PR TITLE
Add trigger description support and update related functionality

### DIFF
--- a/prisma/migrations/20250714091654_add_description_in_trigger/migration.sql
+++ b/prisma/migrations/20250714091654_add_description_in_trigger/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "tbl_triggers" ADD COLUMN     "description" TEXT;

--- a/prisma/migrations/20250715053409_add_description_in_trigger_history/migration.sql
+++ b/prisma/migrations/20250715053409_add_description_in_trigger_history/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "tbl_trigger_history" ADD COLUMN     "description" TEXT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -138,6 +138,7 @@ model Trigger {
   triggerDocuments Json?   @db.JsonB()
   notes            String?
   title            String?
+  description      String?
 
   phase   Phase?      @relation(fields: [phaseId], references: [uuid])
   phaseId String?
@@ -170,6 +171,7 @@ model TriggerHistory {
   triggerDocuments Json?   @db.JsonB()
   notes            String?
   title            String?
+  description      String?
 
   phase   Phase?      @relation(fields: [phaseId], references: [uuid])
   phaseId String?

--- a/src/common/dto.ts
+++ b/src/common/dto.ts
@@ -63,6 +63,9 @@ export class AddTriggerJobDto {
   title: string;
 
   @IsString()
+  description?: string;
+
+  @IsString()
   source: string;
 
   @IsString()

--- a/src/phases/phases.service.ts
+++ b/src/phases/phases.service.ts
@@ -679,6 +679,7 @@ export class PhasesService {
           appId,
           {
             title: trigger.title,
+            description: trigger?.description,
             isMandatory: trigger.isMandatory,
             phaseId: trigger.phaseId,
             source: trigger.source,
@@ -690,6 +691,7 @@ export class PhasesService {
           appId,
           {
             title: trigger.title,
+            description: trigger?.description,
             triggerStatement: JSON.parse(
               JSON.stringify(trigger.triggerStatement),
             ),

--- a/src/trigger-history/trigger-history.service.ts
+++ b/src/trigger-history/trigger-history.service.ts
@@ -67,6 +67,7 @@ export class TriggerHistoryService {
             phaseId: phase.uuid,
           },
           data: {
+            notes: null,
             triggeredAt: null,
             triggeredBy: null,
             isTriggered: false,

--- a/src/trigger/dto/create-trigger.dto.ts
+++ b/src/trigger/dto/create-trigger.dto.ts
@@ -36,6 +36,14 @@ export class CreateTriggerDto {
   title?: string;
 
   @ApiProperty({
+    example: 'Trigger description',
+    description: 'The description of the trigger',
+  })
+  @IsString()
+  @IsOptional()
+  description?: string;
+
+  @ApiProperty({
     example: 'Every day',
     description: 'The repeat frequency of the trigger',
   })

--- a/src/trigger/trigger.service.ts
+++ b/src/trigger/trigger.service.ts
@@ -46,6 +46,7 @@ export class TriggerService {
       } else {
         const sanitizedPayload = {
           title: dto.title,
+          description: dto.description,
           triggerStatement: dto.triggerStatement,
           phaseId: dto.phaseId,
           isMandatory: dto.isMandatory,
@@ -63,6 +64,7 @@ export class TriggerService {
         trigger_type: trigger.isMandatory ? 'MANDATORY' : 'OPTIONAL',
         phase: trigger.phase.name,
         title: trigger.title,
+        description: trigger.description,
         source: trigger.source,
         river_basin: trigger.phase.riverBasin,
         params: JSON.parse(JSON.stringify(trigger.triggerStatement)),
@@ -120,6 +122,7 @@ export class TriggerService {
             repeatEvery: '30000',
             notes: item.notes,
             createdBy,
+            description: item.description,
           };
 
           return await this.scheduleJob(sanitizedPayload);
@@ -131,6 +134,7 @@ export class TriggerService {
           trigger_type: trigger.isMandatory ? 'MANDATORY' : 'OPTIONAL',
           phase: trigger.phase.name,
           title: trigger.title,
+          description: trigger.description,
           source: trigger.source,
           river_basin: trigger.phase.riverBasin,
           params: JSON.parse(JSON.stringify(trigger.triggerStatement)),
@@ -219,6 +223,7 @@ export class TriggerService {
         title: payload.title || trigger.title,
         triggerStatement: payload.triggerStatement || trigger.triggerStatement,
         notes: payload.notes ?? trigger.notes,
+        description: payload.description ?? trigger.description,
         isMandatory: payload.isMandatory ?? trigger.isMandatory,
       };
 


### PR DESCRIPTION
https://github.com/orgs/rahataid/projects/51/views/26?pane=issue&itemId=3230953657&issue=rahataid%7Crahat-project-triggers%7C113

This PR introduces support for a description field in both the Trigger and Trigger_History models and updates related functionalities accordingly:

- Added description column to Trigger and Trigger_History schemas
- Updated trigger create and update methods to handle the new description field
- Removed all trigger notes when a phase is reverted; they are now shown only in Trigger History

