### PR TITLE
fix: update getFormattedDay ana formateGfhStationData fucntions

### DIFF
--- a/src/common/index.ts
+++ b/src/common/index.ts
@@ -1,7 +1,7 @@
 import * as cheerio from 'cheerio';
-export const getFormattedDate = () => {
-  const date = new Date();
-  date.setDate(date.getDate() - 1); // Set date to previous day
+export const getFormattedDate = (date: Date = new Date()) => {
+  // const date = new Date();
+  // date.setDate(date.getDate() - 1); // Set date to previous day
   const year = date.getFullYear();
   const month = String(date.getMonth() + 1).padStart(2, '0'); // getMonth() returns 0-based month, hence add 1
   const day = String(date.getDate()).padStart(2, '0');
@@ -47,7 +47,7 @@ export function parseGlofasData(content: string) {
   }
 
   const returnPeriodTable2yr = parseReturnPeriodTable(rpTable2yr, $);
-  const returnPeriodTable5yr = parseReturnPeriodTable(rpTable5yr, $); 
+  const returnPeriodTable5yr = parseReturnPeriodTable(rpTable5yr, $);
   const returnPeriodTable20yr = parseReturnPeriodTable(rpTable20yr, $);
   const pointForecastData = parsePointForecast(pfTable, $);
   const hydrographImageUrl = hydrographElement.attr('src');

--- a/src/sources-data/gfh.service.ts
+++ b/src/sources-data/gfh.service.ts
@@ -394,12 +394,12 @@ export class GfhService {
       longitude: stationData?.gaugeLocation?.longitude?.toFixed(6),
       stationName: stationName || '',
       warningLevel:
-        stationData.model_metadata?.thresholds?.warningLevel?.toFixed(2) || '',
+        stationData.model_metadata?.thresholds?.warningLevel?.toFixed(3) || '',
       dangerLevel:
-        stationData.model_metadata?.thresholds?.dangerLevel?.toFixed(2) || '',
+        stationData.model_metadata?.thresholds?.dangerLevel?.toFixed(3) || '',
       extremeDangerLevel:
         stationData.model_metadata?.thresholds?.extremeDangerLevel?.toFixed(
-          2,
+          3,
         ) || '',
       basinSize: stationData.model_metadata?.thresholds?.basinSize || 0,
       riverGaugeId: stationData?.gaugeId || '',

--- a/src/sources-data/schedule-sources-data.service.ts
+++ b/src/sources-data/schedule-sources-data.service.ts
@@ -340,7 +340,9 @@ export class ScheduleSourcesDataService implements OnApplicationBootstrap {
         return;
       }
       glofasSettings.forEach(async (glofasStation: GlofasStationInfo) => {
-        const { dateString, dateTimeString } = getFormattedDate();
+        const yesterdayDate = new Date();
+        yesterdayDate.setDate(yesterdayDate.getDate() - 1);
+        const { dateString, dateTimeString } = getFormattedDate(yesterdayDate);
 
         const riverBasin = glofasStation['LOCATION'];
 

--- a/src/sources-data/sources-data.service.ts
+++ b/src/sources-data/sources-data.service.ts
@@ -460,8 +460,9 @@ export class SourcesDataService {
 
     // DHM uses Doda for Dhoda where as Glofas uses Dhoda
     riverBasin = riverBasin.replace('Dhoda', 'Doda');
-
-    const date = getFormattedDate();
+    const yesterdayDate = new Date();
+    yesterdayDate.setDate(yesterdayDate.getDate() - 1);
+    const date = getFormattedDate(yesterdayDate);
 
     const data = await this.findGlofasData(riverBasin, date.dateString);
 


### PR DESCRIPTION
- Refactored `getFormattedDay` function to accept a Date argument and return the formatted date accordingly.
- Updated all usages of the `getFormattedDay` function to match the new signature.
- Enhanced `formatGfhStationData` function:
- Now returns `warning, danger, and extreme danger` levels with values rounded to 3 decimal places (e.g., 2.734).

