### PR TITLE
count session group type

### DIFF
--- a/src/activity/activity.service.ts
+++ b/src/activity/activity.service.ts
@@ -521,7 +521,7 @@ export class ActivityService {
           manager: true,
         },
         orderBy: {
-          createdAt: 'desc',
+          updatedAt: 'desc',
         },
       };
 


### PR DESCRIPTION

  Calculates and saves the count of unique sessions per groupType and appId  based on activity communication data. 
   Stores results with names like:
                    "BENEFICIARY_<appId>" or "STAKEHOLDERS_<appId>" under the 'commsStats' group.
 