### PR TITLE
refactor(triggers): remove mandatory trigger decrement logic

### DIFF
--- a/src/trigger/trigger.service.ts
+++ b/src/trigger/trigger.service.ts
@@ -429,32 +429,6 @@ export class TriggerService {
         },
       });
 
-      if (trigger.isMandatory) {
-        await this.prisma.phase.update({
-          where: {
-            uuid: trigger.phaseId,
-          },
-          data: {
-            requiredMandatoryTriggers: {
-              decrement: 1,
-            },
-          },
-        });
-      }
-
-      // if(!trigger.isMandatory){
-      //   await this.prisma.phases.update({
-      //     where: {
-      //       uuid: trigger.phaseId
-      //     },
-      //     data: {
-      //       requiredOptionalTriggers: {
-      //         decrement: 1
-      //       }
-      //     }
-      //   })
-      // }
-
       this.triggerQueue.add(JOBS.TRIGGER.REACHED_THRESHOLD, trigger, {
         attempts: 3,
         removeOnComplete: true,


### PR DESCRIPTION
Removed mandatory trigger decrement logic during trigger removal. This prevents unintended phase requirement updates while ensuring phase activation still correctly triggers notifications.