### PR TITLE
Refactor findAll category method to return all data if no pagination is provided

### DIFF
--- a/apps/triggers/src/category/category.service.ts
+++ b/apps/triggers/src/category/category.service.ts
@@ -20,24 +20,45 @@ export class CategoryService {
     });
   }
 
-  findAll(payload: ListCategoryDto) {
+  async findAll(payload: ListCategoryDto) {
     const { appId, name, page, perPage } = payload;
 
     const query = {
       where: {
         app: appId,
         isDeleted: false,
-        ...(name && { name: { contains: name, mode: 'insensitive' } }),
+        ...(name && {
+          name: {
+            contains: name,
+            mode: 'insensitive' as const,
+          },
+        }),
       },
       orderBy: {
         // [sort]: order,
       },
     };
 
-    return paginate(this.prisma.activityCategory, query, {
-      page,
-      perPage,
-    });
+    if (page !== undefined && perPage !== undefined) {
+      return paginate(this.prisma.activityCategory, query, {
+        page,
+        perPage,
+      });
+    }
+
+    const data = await this.prisma.activityCategory.findMany(query);
+
+    return {
+      data,
+      meta: {
+        total: data.length,
+        lastPage: 1,
+        currentPage: 1,
+        perPage: data.length,
+        prev: null,
+        next: null,
+      },
+    };
   }
 
   findOne(uuid: string) {

--- a/apps/triggers/src/category/category.service.ts
+++ b/apps/triggers/src/category/category.service.ts
@@ -1,11 +1,8 @@
 import { Injectable } from '@nestjs/common';
 import { CreateCategoryDto } from './dto/create-category.dto';
 import { UpdateCategoryDto } from './dto/update-category.dto';
-import { paginator, PaginatorTypes } from '@lib/database';
 import { ListCategoryDto } from './dto';
 import { PrismaService } from '@lib/database';
-
-const paginate: PaginatorTypes.PaginateFunction = paginator({ perPage: 10 });
 
 @Injectable()
 export class CategoryService {
@@ -20,47 +17,22 @@ export class CategoryService {
     });
   }
 
-  async findAll(payload: ListCategoryDto) {
-    const { appId, name, page, perPage } = payload;
+  findAll(payload: ListCategoryDto) {
+    const { appId, name } = payload;
 
     const query = {
       where: {
         app: appId,
         isDeleted: false,
-        ...(name && {
-          name: {
-            contains: name,
-            mode: 'insensitive' as const,
-          },
-        }),
+        ...(name && { name: { contains: name, mode: 'insensitive' as const } }),
       },
       orderBy: {
         // [sort]: order,
       },
     };
 
-    if (page !== undefined && perPage !== undefined) {
-      return paginate(this.prisma.activityCategory, query, {
-        page,
-        perPage,
-      });
-    }
-
-    const data = await this.prisma.activityCategory.findMany(query);
-
-    return {
-      data,
-      meta: {
-        total: data.length,
-        lastPage: 1,
-        currentPage: 1,
-        perPage: data.length,
-        prev: null,
-        next: null,
-      },
-    };
+    return this.prisma.activityCategory.findMany(query);
   }
-
   findOne(uuid: string) {
     return this.prisma.activityCategory.findUnique({
       where: {

--- a/apps/triggers/src/category/dto/list-category.dto.ts
+++ b/apps/triggers/src/category/dto/list-category.dto.ts
@@ -1,6 +1,5 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { Type } from 'class-transformer';
-import { IsIn, IsNumber, IsOptional, IsString } from 'class-validator';
+import { IsOptional, IsString } from 'class-validator';
 
 export class ListCategoryDto {
   @IsString()
@@ -12,41 +11,4 @@ export class ListCategoryDto {
   @IsString()
   @ApiProperty({ example: '', description: ' app ID' })
   appId?: string;
-
-  @ApiProperty({
-    example: 1,
-    description: 'page number',
-    required: false,
-  })
-  @Type(() => Number)
-  @IsNumber()
-  page?: number = 1;
-
-  @ApiProperty({
-    example: 10,
-    description: 'number of items per page',
-    required: false,
-  })
-  @Type(() => Number)
-  @IsNumber()
-  perPage?: number = 100;
-
-  @ApiProperty({
-    example: 'createdAt',
-    description: 'Sort field',
-    required: false,
-  })
-  @IsOptional()
-  @IsString()
-  sort: string;
-
-  @ApiProperty({
-    example: 'desc',
-    description: 'Sort order',
-    required: false,
-  })
-  @IsOptional()
-  @IsString()
-  @IsIn(['asc', 'desc'])
-  order: 'asc' | 'desc' = 'asc';
 }


### PR DESCRIPTION
### Description

Modified the category listing API to support both paginated and non-paginated responses. When `page` and `perPage` are not provided, the API returns all matching categories.
