### PR TITLE
feat(triggers): add error codes for frontend translation support

### DIFF
--- a/apps/triggers/src/activity/activity.service.ts
+++ b/apps/triggers/src/activity/activity.service.ts
@@ -90,6 +90,7 @@ export class ActivityService {
       return newActivity;
     } catch (error: any) {
       this.logger.error('Something went wrong while adding activity', error);
+      if (error instanceof RpcException) throw error;
       throw new RpcException(error?.message || 'Something went wrong');
     }
   }
@@ -163,7 +164,10 @@ export class ActivityService {
 
   async validateBulkAdd(payload: CreateActivityDto[]) {
     if (!payload?.length) {
-      throw new RpcException('No activities provided');
+      throw new RpcException({
+        message: 'No activities provided',
+        code: 'NO_ACTIVITIES_PROVIDED',
+      });
     }
 
     const appId = payload[0]?.appId;
@@ -244,7 +248,10 @@ export class ActivityService {
 
     try {
       if (!payload?.length) {
-        throw new RpcException('No activities provided');
+        throw new RpcException({
+          message: 'No activities provided',
+          code: 'NO_ACTIVITIES_PROVIDED',
+        });
       }
 
       const createdActivities = await this.prisma.$transaction(
@@ -319,6 +326,7 @@ export class ActivityService {
       };
     } catch (error: any) {
       this.logger.error('Something went wrong while adding activities', error);
+      if (error instanceof RpcException) throw error;
       throw new RpcException(error?.message || 'Something went wrong');
     }
   }
@@ -502,6 +510,7 @@ export class ActivityService {
       };
     } catch (error: any) {
       this.logger.error('Something went wrong while fetching activity', error);
+      if (error instanceof RpcException) throw error;
       throw new RpcException(error?.message || 'Something went wrong');
     }
   }
@@ -578,6 +587,7 @@ export class ActivityService {
         'Something went wrong while fetching activities',
         error,
       );
+      if (error instanceof RpcException) throw error;
       throw new RpcException(error?.message || 'Something went wrong');
     }
   }
@@ -640,6 +650,7 @@ export class ActivityService {
         'Something went wrong while fetching activities',
         error,
       );
+      if (error instanceof RpcException) throw error;
       throw new RpcException(error?.message || 'Something went wrong');
     }
   }
@@ -650,7 +661,10 @@ export class ActivityService {
       const { page, perPage, appId, filters = {} } = payload;
 
       if (!filters.transportName) {
-        throw new RpcException('Transport name not found ');
+        throw new RpcException({
+          message: 'Transport name not found ',
+          code: 'TRANSPORT_NAME_NOT_FOUND',
+        });
       }
 
       // Get base communication data
@@ -702,6 +716,7 @@ export class ActivityService {
         'Something went wrong while fetching activities having communications',
         error,
       );
+      if (error instanceof RpcException) throw error;
       throw new RpcException(error?.message || 'Something went wrong');
     }
   }
@@ -1058,6 +1073,7 @@ export class ActivityService {
         error,
       );
 
+      if (error instanceof RpcException) throw error;
       throw new RpcException(error?.message || 'Something went wrong');
     }
   }
@@ -1080,6 +1096,7 @@ export class ActivityService {
       return deletedActivity;
     } catch (error: any) {
       this.logger.error('Error while deleting activity', error);
+      if (error instanceof RpcException) throw error;
       throw new RpcException(error?.message || 'Something went wrong');
     }
   }
@@ -1103,7 +1120,11 @@ export class ActivityService {
 
       if (!activity) {
         this.logger.warn(`Activity not found: ${uuid}`);
-        throw new RpcException(`Activity not found: ${uuid}`);
+        throw new RpcException({
+          message: `Activity not found: ${uuid}`,
+          code: 'ACTIVITY_NOT_FOUND',
+          params: { uuid },
+        });
       }
 
       const docs = activityDocuments
@@ -1159,6 +1180,7 @@ export class ActivityService {
       return updatedActivity;
     } catch (error: any) {
       this.logger.log('Error while updating activity status', error);
+      if (error instanceof RpcException) throw error;
       throw new RpcException(error?.message || 'Something went wrong');
     }
   }
@@ -1188,7 +1210,10 @@ export class ActivityService {
 
       if (!activity) {
         this.logger.warn('Activity not found');
-        throw new RpcException('Activity not found.');
+        throw new RpcException({
+          message: 'Activity not found.',
+          code: 'ACTIVITY_NOT_FOUND',
+        });
       }
 
       const updateActivityCommunicationPayload = [];
@@ -1254,6 +1279,7 @@ export class ActivityService {
       return updatedActivity;
     } catch (error: any) {
       this.logger.error('Error while updating activity', error);
+      if (error instanceof RpcException) throw error;
       throw new RpcException(error?.message || 'Something went wrong');
     }
   }
@@ -1300,6 +1326,7 @@ export class ActivityService {
       };
     } catch (error: any) {
       this.logger.error('Error while fetching session logs', error);
+      if (error instanceof RpcException) throw error;
       throw new RpcException(error?.message || 'Something went wrong');
     }
   }
@@ -1337,7 +1364,10 @@ export class ActivityService {
 
       if (!activity) {
         this.logger.warn('Activity Communication not found');
-        throw new RpcException('Activity communication not found.');
+        throw new RpcException({
+          message: 'Activity communication not found.',
+          code: 'ACTIVITY_COMMUNICATION_NOT_FOUND',
+        });
       }
 
       const { activityCommunication } = activity;
@@ -1366,13 +1396,17 @@ export class ActivityService {
         this.logger.warn(
           "Selected Communication doesn't exist in current activity",
         );
-        throw new RpcException(
-          "Selected Communication doesn't exist in current activity",
-        );
+        throw new RpcException({
+          message: "Selected Communication doesn't exist in current activity",
+          code: 'SELECTED_COMMUNICATION_NOT_IN_ACTIVITY',
+        });
       }
 
       if (!Object.keys(selectedCommunication).length) {
-        throw new RpcException('Selected communication not found.');
+        throw new RpcException({
+          message: 'Selected communication not found.',
+          code: 'SELECTED_COMMUNICATION_NOT_FOUND',
+        });
       }
 
       return { selectedCommunication, activity };
@@ -1381,6 +1415,7 @@ export class ActivityService {
         'Error while fetching activity communication details',
         error,
       );
+      if (error instanceof RpcException) throw error;
       throw new RpcException(error?.message || 'Something went wrong');
     }
   }
@@ -1426,6 +1461,7 @@ export class ActivityService {
       return { group, groupName };
     } catch (error: any) {
       this.logger.error('Error while fetching group details', error);
+      if (error instanceof RpcException) throw error;
       throw new RpcException(error?.message || 'Something went wrong');
     }
   }
@@ -1466,6 +1502,7 @@ export class ActivityService {
       };
     } catch (error: any) {
       this.logger.error('Error while fetching communication stats', error);
+      if (error instanceof RpcException) throw error;
       throw new RpcException(error?.message || 'Something went wrong');
     }
   }
@@ -1475,7 +1512,10 @@ export class ActivityService {
 
     if (!appId) {
       this.logger.warn('App ID is missing');
-      throw new RpcException('App ID is missing');
+      throw new RpcException({
+        message: 'App ID is missing',
+        code: 'APP_ID_MISSING',
+      });
     }
 
     try {
@@ -1520,6 +1560,7 @@ export class ActivityService {
       return result;
     } catch (error: any) {
       this.logger.error('Error while fetching transport session stats', error);
+      if (error instanceof RpcException) throw error;
       throw new RpcException(error?.message || 'Something went wrong');
     }
   }
@@ -1531,7 +1572,10 @@ export class ActivityService {
   }) {
     if (!payload?.communicationId || !payload?.activityId) {
       this.logger.warn('Communication ID or Activity ID is missing');
-      throw new RpcException('Communication ID or Activity ID is missing');
+      throw new RpcException({
+        message: 'Communication ID or Activity ID is missing',
+        code: 'COMM_OR_ACTIVITY_ID_MISSING',
+      });
     }
 
     this.logger.log(`Triggering communication for ${payload.activityId}`);
@@ -1540,7 +1584,11 @@ export class ActivityService {
         uuid: payload.activityId,
       },
     });
-    if (!activity) throw new RpcException('Activity communication not found.');
+    if (!activity)
+      throw new RpcException({
+        message: 'Activity communication not found.',
+        code: 'ACTIVITY_COMMUNICATION_NOT_FOUND',
+      });
     const { activityCommunication } = activity;
 
     const parsedCommunications = JSON.parse(
@@ -1564,7 +1612,10 @@ export class ActivityService {
     );
 
     if (!Object.keys(selectedCommunication).length)
-      throw new RpcException('Selected communication not found.');
+      throw new RpcException({
+        message: 'Selected communication not found.',
+        code: 'SELECTED_COMMUNICATION_NOT_FOUND',
+      });
 
     const transportDetails = await this.commsClient.transport.get(
       selectedCommunication.transportId,
@@ -1572,7 +1623,10 @@ export class ActivityService {
 
     if (!transportDetails.data) {
       this.logger.warn('Selected transport not found');
-      throw new RpcException('Selected transport not found.');
+      throw new RpcException({
+        message: 'Selected transport not found.',
+        code: 'SELECTED_TRANSPORT_NOT_FOUND',
+      });
     }
 
     const addresses = await this.getAddresses(
@@ -1618,7 +1672,10 @@ export class ActivityService {
 
     if (!sessionData) {
       this.logger.warn('Session not found');
-      throw new RpcException('Session not found.');
+      throw new RpcException({
+        message: 'Session not found.',
+        code: 'SESSION_NOT_FOUND',
+      });
     }
 
     const updatedCommunicationsData = parsedCommunications.map((c) => {
@@ -1655,7 +1712,11 @@ export class ActivityService {
 
     switch (groupType) {
       case 'STAKEHOLDERS':
-        if (!group) throw new RpcException('Stakeholders group not found.');
+        if (!group)
+          throw new RpcException({
+            message: 'Stakeholders group not found.',
+            code: 'STAKEHOLDERS_GROUP_NOT_FOUND',
+          });
         //  Extract and validate contact addresses for stakeholders
         return group.stakeholders
           .map((stakeholder) => {
@@ -1681,7 +1742,11 @@ export class ActivityService {
           })
           .filter(Boolean);
       case 'BENEFICIARY':
-        if (!group) throw new RpcException('Beneficiary group not found.');
+        if (!group)
+          throw new RpcException({
+            message: 'Beneficiary group not found.',
+            code: 'BENEFICIARY_GROUP_NOT_FOUND',
+          });
 
         const groupedBeneficiaries = group.groupedBeneficiaries;
         //  Extract and validate contact addresses for beneficiaries
@@ -1818,6 +1883,7 @@ export class ActivityService {
       return result;
     } catch (error: any) {
       this.logger.error('Error while fetching group details', error);
+      if (error instanceof RpcException) throw error;
       throw new RpcException(error);
     }
   }
@@ -1849,6 +1915,7 @@ export class ActivityService {
         `Error while fetching activities for stakeholder ${stakeholderGroupUuid}`,
         error,
       );
+      if (error instanceof RpcException) throw error;
       throw new RpcException(error?.message || 'Something went wrong');
     }
   }

--- a/apps/triggers/src/activity/activity.service.ts
+++ b/apps/triggers/src/activity/activity.service.ts
@@ -1452,10 +1452,16 @@ export class ActivityService {
         );
         groupName = group.name;
       } else {
-        throw new Error('Invalid group type');
+        throw new RpcException({
+          message: 'Invalid group type',
+          code: 'INVALID_GROUP_TYPE',
+        });
       }
       if (!group) {
-        throw new Error('No response from microservice');
+        throw new RpcException({
+          message: 'No response from microservice',
+          code: 'NO_RESPONSE_FROM_MICROSERVICE',
+        });
       }
 
       return { group, groupName };

--- a/apps/triggers/src/comms/comms.service.ts
+++ b/apps/triggers/src/comms/comms.service.ts
@@ -1,5 +1,5 @@
 import { Inject, Injectable, Logger } from '@nestjs/common';
-import { ClientProxy } from '@nestjs/microservices';
+import { ClientProxy, RpcException } from '@nestjs/microservices';
 import { lastValueFrom, timeout } from 'rxjs';
 import { getClient } from '@rumsan/connect/src/clients';
 
@@ -43,7 +43,10 @@ export class CommsService {
       );
 
       if (!communicationSettings) {
-        throw new Error('Communication settings not found in response');
+        throw new RpcException({
+          message: 'Communication settings not found in response',
+          code: 'COMMUNICATION_SETTINGS_NOT_FOUND',
+        });
       }
 
       this.client = getClient({

--- a/apps/triggers/src/daily-monitoring/daily-monitoring.service.ts
+++ b/apps/triggers/src/daily-monitoring/daily-monitoring.service.ts
@@ -24,7 +24,11 @@ export class DailyMonitoringService {
         where: { riverBasin },
       });
 
-      if (!source) throw new NotFoundException('Source not found');
+      if (!source)
+        throw new NotFoundException({
+          message: 'Source not found',
+          code: 'SOURCE_NOT_FOUND',
+        });
 
       return Promise.all(
         rest.data?.map((entry) =>
@@ -41,7 +45,10 @@ export class DailyMonitoringService {
       );
     } catch (error: any) {
       this.logger.error(error);
-      throw new RpcException('Failed to create daily monitoring data');
+      throw new RpcException({
+        message: 'Failed to create daily monitoring data',
+        code: 'DAILY_MONITORING_CREATE_FAILED',
+      });
     }
   }
 
@@ -96,7 +103,10 @@ export class DailyMonitoringService {
       return { results: transformedData };
     } catch (error: any) {
       this.logger.error(error);
-      throw new RpcException('Failed to fetch daily monitoring data');
+      throw new RpcException({
+        message: 'Failed to fetch daily monitoring data',
+        code: 'DAILY_MONITORING_FETCH_FAILED',
+      });
     }
   }
 
@@ -145,7 +155,10 @@ export class DailyMonitoringService {
       // };
     } catch (error: any) {
       this.logger.error(error);
-      throw new RpcException('Failed to fetch daily monitoring data');
+      throw new RpcException({
+        message: 'Failed to fetch daily monitoring data',
+        code: 'DAILY_MONITORING_FETCH_FAILED',
+      });
     }
   }
 
@@ -173,7 +186,10 @@ export class DailyMonitoringService {
       return groupedData;
     } catch (error: any) {
       this.logger.error('Error fetching gauge reading data:', error);
-      throw new RpcException('Failed to fetch gauge reading data');
+      throw new RpcException({
+        message: 'Failed to fetch gauge reading data',
+        code: 'GAUGE_READING_FETCH_FAILED',
+      });
     }
   }
 
@@ -315,7 +331,10 @@ export class DailyMonitoringService {
       });
     } catch (error: any) {
       this.logger.error('Error fetching gauge forecast data:', error.message);
-      throw new RpcException('Failed to fetch gauge forecast data');
+      throw new RpcException({
+        message: 'Failed to fetch gauge forecast data',
+        code: 'GAUGE_FORECAST_FETCH_FAILED',
+      });
     }
   }
 
@@ -392,7 +411,10 @@ export class DailyMonitoringService {
       });
     } catch (error: any) {
       this.logger.error(error);
-      throw new RpcException('Failed to delete daily monitoring data');
+      throw new RpcException({
+        message: 'Failed to delete daily monitoring data',
+        code: 'DAILY_MONITORING_DELETE_FAILED',
+      });
     }
   }
 
@@ -413,7 +435,10 @@ export class DailyMonitoringService {
       });
     } catch (error: any) {
       this.logger.error(error);
-      throw new RpcException('Failed to delete daily monitoring data');
+      throw new RpcException({
+        message: 'Failed to delete daily monitoring data',
+        code: 'DAILY_MONITORING_DELETE_FAILED',
+      });
     }
   }
   sameGroupeKeyMergeData(response) {

--- a/apps/triggers/src/library/library.service.ts
+++ b/apps/triggers/src/library/library.service.ts
@@ -77,9 +77,10 @@ export class LibraryService {
         'Failed to fetch activity templates from library',
         error,
       );
-      throw new RpcException(
-        error?.message || 'Failed to fetch activity templates',
-      );
+      throw new RpcException({
+        message: error?.message || 'Failed to fetch activity templates',
+        code: 'LIBRARY_TEMPLATES_FETCH_FAILED',
+      });
     }
   }
 
@@ -112,7 +113,10 @@ export class LibraryService {
       });
 
       if (!dbTemplate) {
-        throw new RpcException('Activity template not found');
+        throw new RpcException({
+          message: 'Activity template not found',
+          code: 'ACTIVITY_TEMPLATE_NOT_FOUND',
+        });
       }
 
       return dbTemplate;

--- a/apps/triggers/src/phases/phases.controller.ts
+++ b/apps/triggers/src/phases/phases.controller.ts
@@ -75,7 +75,10 @@ export class PhasesController {
       return await this.phasesService.activatePhase(dto.phaseUuid);
     }
 
-    throw new RpcException('Not allowed in production environment');
+    throw new RpcException({
+      message: 'Not allowed in production environment',
+      code: 'NOT_ALLOWED_PRODUCTION',
+    });
   }
 
   @MessagePattern({

--- a/apps/triggers/src/phases/phases.service.ts
+++ b/apps/triggers/src/phases/phases.service.ts
@@ -75,12 +75,18 @@ export class PhasesService {
 
     if (!name || !source || !river_basin) {
       this.logger.error('Missing required fields in payload');
-      throw new RpcException('Name, source and river basin are required');
+      throw new RpcException({
+        message: 'Name, source and river basin are required',
+        code: 'PHASE_REQUIRED_FIELDS',
+      });
     }
 
     if (!activeYear) {
       this.logger.error('Missing active year in payload');
-      throw new RpcException('Active year is required');
+      throw new RpcException({
+        message: 'Active year is required',
+        code: 'ACTIVE_YEAR_REQUIRED',
+      });
     }
 
     const existingPhase = await this.prisma.phase.findFirst({
@@ -97,15 +103,18 @@ export class PhasesService {
       this.logger.warn(
         `Phase with name ${name}, activeYear ${activeYear} and riverBasin ${river_basin} already exists`,
       );
-      throw new RpcException(
-        `Phase with name ${name}, activeYear ${activeYear} and riverBasin ${river_basin} already exists`,
-      );
+      throw new RpcException({
+        message: `Phase with name ${name}, activeYear ${activeYear} and riverBasin ${river_basin} already exists`,
+        code: 'PHASE_ALREADY_EXISTS',
+        params: { name, activeYear, river_basin },
+      });
     }
 
     if (canTriggerPayout && !disbursementMethods?.length) {
-      throw new RpcException(
-        'disbursementMethods is required when canTriggerPayout is true',
-      );
+      throw new RpcException({
+        message: 'disbursementMethods is required when canTriggerPayout is true',
+        code: 'DISBURSEMENT_METHODS_REQUIRED_FOR_PAYOUT',
+      });
     }
 
     if (disbursementMethods?.length) {
@@ -148,6 +157,7 @@ export class PhasesService {
       return phase;
     } catch (error: any) {
       this.logger.error('Error while creating new Phase', error);
+      if (error instanceof RpcException) throw error;
       throw new RpcException(error);
     }
   }
@@ -222,13 +232,17 @@ export class PhasesService {
     const phase = await this.findOrThrow(uuid);
 
     if (phase.isActive) {
-      throw new RpcException('Cannot update an active phase');
+      throw new RpcException({
+        message: 'Cannot update an active phase',
+        code: 'CANNOT_UPDATE_ACTIVE_PHASE',
+      });
     }
 
     if (rest.canTriggerPayout && !rest.disbursementMethods?.length) {
-      throw new RpcException(
-        'disbursementMethods is required when canTriggerPayout is true',
-      );
+      throw new RpcException({
+        message: 'disbursementMethods is required when canTriggerPayout is true',
+        code: 'DISBURSEMENT_METHODS_REQUIRED_FOR_PAYOUT',
+      });
     }
 
     if (rest.disbursementMethods?.length) {
@@ -272,6 +286,7 @@ export class PhasesService {
       return phase;
     } catch (error: any) {
       this.logger.error('Error while updating phase', error);
+      if (error instanceof RpcException) throw error;
       throw new RpcException(error);
     }
   }
@@ -304,6 +319,7 @@ export class PhasesService {
       return { ...phase, triggerRequirements };
     } catch (error: any) {
       this.logger.error('Error while fetching phase', error);
+      if (error instanceof RpcException) throw error;
       throw new RpcException(error);
     }
   }
@@ -317,7 +333,10 @@ export class PhasesService {
     if (!uuid) {
       if (!activeYear || !riverBasin) {
         this.logger.warn('Active year and river basin are required');
-        throw new RpcException('Active year and river basin are required');
+        throw new RpcException({
+          message: 'Active year and river basin are required',
+          code: 'ACTIVE_YEAR_AND_RIVER_BASIN_REQUIRED',
+        });
       }
 
       phaseDetails = await this.prisma.phase.findFirst({
@@ -354,7 +373,11 @@ export class PhasesService {
 
     if (!phaseDetails) {
       this.logger.warn(`Phase with uuid ${uuid} not found`);
-      throw new RpcException(`Phase with uuid ${uuid} not found`);
+      throw new RpcException({
+        message: `Phase with uuid ${uuid} not found`,
+        code: 'PHASE_NOT_FOUND',
+        params: { uuid },
+      });
     }
 
     const triggerStash =
@@ -394,6 +417,7 @@ export class PhasesService {
       });
     } catch (error: any) {
       this.logger.error('Error while fetching phase by source', error);
+      if (error instanceof RpcException) throw error;
       throw new RpcException(error);
     }
   }
@@ -632,14 +656,19 @@ export class PhasesService {
 
       if (!phase) {
         this.logger.warn(`Phase with uuid ${uuid} not found`);
-        throw new RpcException(`Phase with uuid ${uuid} not found`);
+        throw new RpcException({
+          message: `Phase with uuid ${uuid} not found`,
+          code: 'PHASE_NOT_FOUND',
+          params: { uuid },
+        });
       }
 
       if (phase.isActive) {
         this.logger.warn('Cannot add triggers to an active phase.');
-        throw new BadRequestException(
-          'Cannot add triggers to an active phase.',
-        );
+        throw new BadRequestException({
+          message: 'Cannot add triggers to an active phase.',
+          code: 'CANNOT_ADD_TRIGGERS_ACTIVE_PHASE',
+        });
       }
 
       for (const trigger of triggers) {
@@ -669,6 +698,7 @@ export class PhasesService {
       return updatedPhase;
     } catch (error: any) {
       this.logger.error('Error while adding triggers to phase', error);
+      if (error instanceof RpcException) throw error;
       throw new RpcException(error);
     }
   }
@@ -718,12 +748,20 @@ export class PhasesService {
 
     if (!phase) {
       this.logger.log(`Phase with uuid ${phaseId} not found`);
-      throw new RpcException('Phase not found.');
+      throw new RpcException({
+        message: 'Phase not found.',
+        code: 'PHASE_NOT_FOUND',
+        params: { uuid: phaseId },
+      });
     }
 
     if (!phase.Trigger.length || !phase.isActive || !phase.canRevert) {
       this.logger.log(`Phase with uuid ${phaseId} cannot be reverted`);
-      throw new RpcException('Phase cannot be reverted.');
+      throw new RpcException({
+        message: 'Phase cannot be reverted.',
+        code: 'PHASE_CANNOT_BE_REVERTED',
+        params: { phaseUuid: phaseId },
+      });
     }
 
     for (const trigger of phase.Trigger) {
@@ -804,6 +842,7 @@ export class PhasesService {
       });
     } catch (error: any) {
       this.logger.error('Error while fetching phase by location', error);
+      if (error instanceof RpcException) throw error;
       throw new RpcException(error);
     }
   }
@@ -830,7 +869,11 @@ export class PhasesService {
 
     if (!phase) {
       this.logger.warn(`Phase with uuid ${uuid} not found`);
-      throw new RpcException(`Phase with uuid ${uuid} not found`);
+      throw new RpcException({
+        message: `Phase with uuid ${uuid} not found`,
+        code: 'PHASE_NOT_FOUND',
+        params: { uuid },
+      });
     }
 
     return phase;
@@ -860,9 +903,16 @@ export class PhasesService {
         this.logger.warn(
           `Disbursement method "${method}" already assigned to phase "${conflict.name}" (${conflict.activeYear}) for riverBasin ${riverBasin}`,
         );
-        throw new RpcException(
-          `Disbursement method "${method}" is already assigned to phase "${conflict.name}" (${conflict.activeYear}) for riverBasin ${riverBasin}. Each method can only be used by one phase per project.`,
-        );
+        throw new RpcException({
+          message: `Disbursement method "${method}" is already assigned to phase "${conflict.name}" (${conflict.activeYear}) for riverBasin ${riverBasin}. Each method can only be used by one phase per project.`,
+          code: 'DISBURSEMENT_METHOD_ALREADY_ASSIGNED_TO_PHASE',
+          params: {
+            method,
+            phaseName: conflict.name,
+            activeYear: conflict.activeYear,
+            riverBasin,
+          },
+        });
       }
     }
   }
@@ -874,7 +924,10 @@ export class PhasesService {
 
     if (phase.isActive) {
       this.logger.warn(`Cannot delete an active phase: ${uuid}`);
-      throw new RpcException('Cannot delete an active phase');
+      throw new RpcException({
+        message: 'Cannot delete an active phase',
+        code: 'CANNOT_DELETE_ACTIVE_PHASE',
+      });
     }
 
     const [triggerCount, activityCount] = await Promise.all([
@@ -896,18 +949,22 @@ export class PhasesService {
       this.logger.warn(
         `Cannot delete phase ${uuid}: ${triggerCount} trigger(s) are associated with this phase`,
       );
-      throw new RpcException(
-        `Cannot delete phase "${phase.name}" (${phase.activeYear}): ${triggerCount} trigger(s) are associated with it. Please remove them first.`,
-      );
+      throw new RpcException({
+        message: `Cannot delete phase "${phase.name}" (${phase.activeYear}): ${triggerCount} trigger(s) are associated with it. Please remove them first.`,
+        code: 'CANNOT_DELETE_PHASE_WITH_TRIGGERS',
+        params: { name: phase.name, activeYear: phase.activeYear, count: triggerCount },
+      });
     }
 
     if (activityCount > 0) {
       this.logger.warn(
         `Cannot delete phase ${uuid}: ${activityCount} activity(s) are associated with this phase`,
       );
-      throw new RpcException(
-        `Cannot delete phase "${phase.name}" (${phase.activeYear}): ${activityCount} activity(s) are associated with it. Please remove them first.`,
-      );
+      throw new RpcException({
+        message: `Cannot delete phase "${phase.name}" (${phase.activeYear}): ${activityCount} activity(s) are associated with it. Please remove them first.`,
+        code: 'CANNOT_DELETE_PHASE_WITH_ACTIVITIES',
+        params: { name: phase.name, activeYear: phase.activeYear, count: activityCount },
+      });
     }
 
     try {
@@ -918,6 +975,7 @@ export class PhasesService {
       return deleted;
     } catch (error: any) {
       this.logger.error('Error while deleting phase', error);
+      if (error instanceof RpcException) throw error;
       throw new RpcException(error?.message || 'Something went wrong');
     }
   }
@@ -930,12 +988,18 @@ export class PhasesService {
     const { activeYear, riverBasin, disbursementMethod } = payload;
     if (!activeYear || !riverBasin) {
       this.logger.warn('activeYear and riverBasin are required');
-      throw new RpcException('activeYear and riverBasin are required');
+      throw new RpcException({
+        message: 'activeYear and riverBasin are required',
+        code: 'ACTIVE_YEAR_AND_RIVER_BASIN_REQUIRED',
+      });
     }
 
     if (!disbursementMethod) {
       this.logger.warn('disbursementMethod is required');
-      throw new RpcException('disbursementMethod is required');
+      throw new RpcException({
+        message: 'disbursementMethod is required',
+        code: 'DISBURSEMENT_METHOD_REQUIRED',
+      });
     }
 
     const phases = await this.prisma.phase.findMany({
@@ -980,9 +1044,10 @@ export class PhasesService {
       this.logger.warn(
         `Cannot set extended trigger logic for active phase ${uuid}`,
       );
-      throw new RpcException(
-        'Cannot update extended trigger logic on an active phase',
-      );
+      throw new RpcException({
+        message: 'Cannot update extended trigger logic on an active phase',
+        code: 'CANNOT_UPDATE_EXTENDED_TRIGGER_LOGIC_ACTIVE_PHASE',
+      });
     }
 
     this.logger.debug(`Persisting extended trigger logic for phase ${uuid}`);
@@ -1011,9 +1076,10 @@ export class PhasesService {
       this.logger.warn(
         `Cannot remove extended trigger logic for active phase ${uuid}`,
       );
-      throw new RpcException(
-        'Cannot remove extended trigger logic from an active phase',
-      );
+      throw new RpcException({
+        message: 'Cannot remove extended trigger logic from an active phase',
+        code: 'CANNOT_REMOVE_EXTENDED_TRIGGER_LOGIC_ACTIVE_PHASE',
+      });
     }
 
     return this.prisma.phase.update({

--- a/apps/triggers/src/source/source.service.ts
+++ b/apps/triggers/src/source/source.service.ts
@@ -31,6 +31,7 @@ export class SourceService {
       return paginatedData;
     } catch (error: any) {
       this.logger.error(`Error fetching sources: ${error}`, error);
+      if (error instanceof RpcException) throw error;
       throw new RpcException(error);
     }
   }
@@ -47,7 +48,11 @@ export class SourceService {
 
       if (!source) {
         this.logger.warn(`Source with UUID: ${dto.uuid} not found`);
-        throw new RpcException(`Source with UUID: ${dto.uuid} not found`);
+        throw new RpcException({
+          message: `Source with UUID: ${dto.uuid} not found`,
+          code: 'SOURCE_NOT_FOUND',
+          params: { uuid: dto.uuid },
+        });
       }
 
       return source;
@@ -56,6 +61,7 @@ export class SourceService {
         `Error fetching source with UUID: ${dto.uuid}: ${error}`,
         error,
       );
+      if (error instanceof RpcException) throw error;
       throw new RpcException(error);
     }
   }

--- a/apps/triggers/src/sources-data/sources-data.service.ts
+++ b/apps/triggers/src/sources-data/sources-data.service.ts
@@ -68,6 +68,7 @@ export class SourcesDataService {
       });
     } catch (error: any) {
       this.logger.error('Error while creatiing new source data', error);
+      if (error instanceof RpcException) throw error;
       throw new RpcException(error);
     }
   }
@@ -90,6 +91,7 @@ export class SourcesDataService {
       );
     } catch (error: any) {
       this.logger.error('Error while fetching source data', error);
+      if (error instanceof RpcException) throw error;
       throw new RpcException(error);
     }
   }
@@ -129,6 +131,7 @@ export class SourcesDataService {
       }
     } catch (error: any) {
       this.logger.error('Error while fetching source data', error);
+      if (error instanceof RpcException) throw error;
       throw new RpcException(error);
     }
   }
@@ -146,6 +149,7 @@ export class SourcesDataService {
         `Error while fetching source data with id: ${id}`,
         error,
       );
+      if (error instanceof RpcException) throw error;
       throw new RpcException(error);
     }
   }
@@ -171,6 +175,7 @@ export class SourcesDataService {
       });
     } catch (error: any) {
       this.logger.error('Error while updating source data info', error);
+      if (error instanceof RpcException) throw error;
       throw new RpcException(error);
     }
   }
@@ -181,9 +186,11 @@ export class SourcesDataService {
       return await this.getLevels(payload, SourceType.WATER_LEVEL);
     } catch (error: any) {
       this.logger.error(`Error while getting water levels: ${error}`);
-      throw new RpcException(
-        `Failed to fetch water levels: '${error.message}'`,
-      );
+      throw new RpcException({
+        message: `Failed to fetch water levels: '${error.message}'`,
+        code: 'FAILED_FETCH_WATER_LEVELS',
+        params: { message: error.message },
+      });
     }
   }
 
@@ -196,9 +203,11 @@ export class SourcesDataService {
       return await this.getHeatwaveLevels(payload, sourceType);
     } catch (error: any) {
       this.logger.error(`Error while getting temperature data: ${error}`);
-      throw new RpcException(
-        `Failed to fetch temperature data: '${error.message}'`,
-      );
+      throw new RpcException({
+        message: `Failed to fetch temperature data: '${error.message}'`,
+        code: 'FAILED_FETCH_TEMPERATURE_DATA',
+        params: { message: error.message },
+      });
     }
   }
   async getRainfallLevels(payload: GetSouceDataDto) {
@@ -207,7 +216,10 @@ export class SourcesDataService {
       return await this.getLevels(payload, SourceType.RAINFALL);
     } catch (error: any) {
       this.logger.error(`Error while getting rainfall data: ${error}`);
-      throw new RpcException('Failed to fetch rainfall data');
+      throw new RpcException({
+        message: 'Failed to fetch rainfall data',
+        code: 'FAILED_FETCH_RAINFALL_DATA',
+      });
     }
   }
 
@@ -230,7 +242,10 @@ export class SourcesDataService {
 
     if (!riverBasin) {
       this.logger.warn('River basin is not passed in the payload');
-      throw new RpcException('River basin is required');
+      throw new RpcException({
+        message: 'River basin is required',
+        code: 'RIVER_BASIN_REQUIRED',
+      });
     }
 
     if (source === DataSource.GFH) {
@@ -243,7 +258,10 @@ export class SourcesDataService {
 
     if (!type) {
       this.logger.warn('Type is not passed in the payload');
-      throw new RpcException('Type is required');
+      throw new RpcException({
+        message: 'Type is required',
+        code: 'TYPE_REQUIRED',
+      });
     }
 
     const sourcesData = await this.prisma.sourcesData.findMany({
@@ -286,13 +304,17 @@ export class SourcesDataService {
 
     if (!riverBasin) {
       this.logger.warn('River basin is not passed in the payload');
-      throw new RpcException('River basin is required');
+      throw new RpcException({
+        message: 'River basin is required',
+        code: 'RIVER_BASIN_REQUIRED',
+      });
     }
 
     if (source !== DataSource.DHM) {
-      throw new RpcException(
-        'Temperature data is only available for DHM source',
-      );
+      throw new RpcException({
+        message: 'Temperature data is only available for DHM source',
+        code: 'TEMPERATURE_ONLY_DHM',
+      });
     }
 
     const temperatureSourcesData = await this.prisma.sourcesData.findMany({
@@ -321,9 +343,11 @@ export class SourcesDataService {
       this.logger.error(
         `No temperatureSourcesData found for river basin: ${riverBasin}, type: ${type}, dataSource: ${source}`,
       );
-      throw new RpcException(
-        `No temperatureSourcesData found for river basin: ${riverBasin}, type: ${type}, dataSource: ${source}`,
-      );
+      throw new RpcException({
+        message: `No temperatureSourcesData found for river basin: ${riverBasin}, type: ${type}, dataSource: ${source}`,
+        code: 'NO_TEMPERATURE_DATA_FOUND',
+        params: { riverBasin, type, source },
+      });
     }
 
     const infos = temperatureSourcesData?.map((item) => item.info);
@@ -481,7 +505,10 @@ export class SourcesDataService {
       !this.isDateWithinLast14Days(new Date(to))
     ) {
       this.logger.error('Dates must be within the last 14 days');
-      throw new RpcException('Dates must be within the last 14 days');
+      throw new RpcException({
+        message: 'Dates must be within the last 14 days',
+        code: 'DATES_WITHIN_14_DAYS',
+      });
     }
     const result = await this.scheduleSourcesDataService.getDhmWaterLevels(
       from,
@@ -530,9 +557,11 @@ export class SourcesDataService {
       this.logger.error(
         `No heatwave data found for payload: ${Object.values(payload).join(',')}`,
       );
-      throw new RpcException(
-        `No heatwave data found for payload: ${Object.values(payload).join(',')}`,
-      );
+      throw new RpcException({
+        message: `No heatwave data found for payload: ${Object.values(payload).join(',')}`,
+        code: 'NO_HEATWAVE_DATA_FOUND',
+        params: { payload: Object.values(payload).join(',') },
+      });
     }
 
     return record;

--- a/apps/triggers/src/trigger-history/trigger-history.service.ts
+++ b/apps/triggers/src/trigger-history/trigger-history.service.ts
@@ -25,21 +25,27 @@ export class TriggerHistoryService {
       });
 
       if (!phase) {
-        throw new RpcException(
-          `Phase with uuid '${payload.phaseUuid}' not found`,
-        );
+        throw new RpcException({
+          message: `Phase with uuid '${payload.phaseUuid}' not found`,
+          code: 'PHASE_NOT_FOUND',
+          params: { phaseUuid: payload.phaseUuid },
+        });
       }
 
       if (!phase.canRevert) {
-        throw new RpcException(
-          `Phase with uuid '${payload.phaseUuid}' cannot be reverted`,
-        );
+        throw new RpcException({
+          message: `Phase with uuid '${payload.phaseUuid}' cannot be reverted`,
+          code: 'PHASE_CANNOT_BE_REVERTED',
+          params: { phaseUuid: payload.phaseUuid },
+        });
       }
 
       if (!phase.isActive) {
-        throw new RpcException(
-          `Phase with uuid '${payload.phaseUuid}' is not active`,
-        );
+        throw new RpcException({
+          message: `Phase with uuid '${payload.phaseUuid}' is not active`,
+          code: 'PHASE_NOT_ACTIVE',
+          params: { phaseUuid: payload.phaseUuid },
+        });
       }
 
       const currentVersion =
@@ -90,12 +96,14 @@ export class TriggerHistoryService {
 
         return {
           message: 'Phase reverted successfully',
+          code: 'PHASE_REVERTED_SUCCESS',
           phase: res,
           version: currentVersion + 1,
         };
       });
     } catch (error: any) {
       this.logger.error('Error creating trigger history', error);
+      if (error instanceof RpcException) throw error;
       throw new RpcException(error?.message || 'Something went wrong');
     }
   }
@@ -105,7 +113,10 @@ export class TriggerHistoryService {
       `Fetching trigger histories for phase: ${payload.phaseUuid}`,
     );
     if (!payload.phaseUuid) {
-      throw new RpcException('Phase uuid is required');
+      throw new RpcException({
+        message: 'Phase uuid is required',
+        code: 'UUID_REQUIRED',
+      });
     }
     try {
       const triggerHistories = await this.prisma.triggerHistory.findMany({
@@ -164,6 +175,7 @@ export class TriggerHistoryService {
       };
     } catch (error: any) {
       this.logger.error('Error fetching trigger histories', error);
+      if (error instanceof RpcException) throw error;
       throw new RpcException(error?.message || 'Something went wrong');
     }
   }
@@ -183,6 +195,7 @@ export class TriggerHistoryService {
       return res?.version;
     } catch (error: any) {
       this.logger.error('Error fetching current version', error);
+      if (error instanceof RpcException) throw error;
       throw new RpcException(error?.message || 'Something went wrong');
     }
   }
@@ -205,6 +218,7 @@ export class TriggerHistoryService {
       });
     } catch (error: any) {
       this.logger.error(error.message);
+      if (error instanceof RpcException) throw error;
       throw new RpcException(error.message);
     }
   }

--- a/apps/triggers/src/trigger/trigger.service.ts
+++ b/apps/triggers/src/trigger/trigger.service.ts
@@ -54,7 +54,10 @@ export class TriggerService {
     const { user, appId, triggers } = payload;
 
     if (!appId) {
-      throw new BadRequestException('appId is required');
+      throw new BadRequestException({
+        message: 'appId is required',
+        code: 'APP_ID_REQUIRED',
+      });
     }
 
     try {
@@ -75,6 +78,7 @@ export class TriggerService {
       return triggersData;
     } catch (error: any) {
       this.logger.error(`Error in create triggers for app ${appId}:`, error);
+      if (error instanceof RpcException) throw error;
       throw new RpcException(error.message);
     }
   }
@@ -100,6 +104,8 @@ export class TriggerService {
       );
       throw new BadRequestException({
         message: `Invalid trigger payload: ${JSON.stringify(result.error.flatten())}`,
+        code: 'INVALID_TRIGGER_PAYLOAD',
+        params: { zodErrors: JSON.stringify(result.error.flatten()) },
       });
     }
 
@@ -121,7 +127,10 @@ export class TriggerService {
 
       if (!trigger) {
         this.logger.warn('Trigger not found.');
-        throw new RpcException('Trigger not found.');
+        throw new RpcException({
+          message: 'Trigger not found.',
+          code: 'TRIGGER_NOT_FOUND',
+        });
       }
 
       const updatedTrigger = await this.prisma.trigger.update({
@@ -139,6 +148,7 @@ export class TriggerService {
         `Error in updating trigger transaction hash on trigger with uuid: ${uuid}:`,
         error,
       );
+      if (error instanceof RpcException) throw error;
       throw new RpcException(error.message);
     }
   }
@@ -149,10 +159,16 @@ export class TriggerService {
     this.logger.log(`Updating trigger with uuid: ${uuid}`);
 
     if (!uuid) {
-      throw new BadRequestException('uuid is required');
+      throw new BadRequestException({
+        message: 'uuid is required',
+        code: 'UUID_REQUIRED',
+      });
     }
     if (!appId) {
-      throw new BadRequestException('appId is required');
+      throw new BadRequestException({
+        message: 'appId is required',
+        code: 'APP_ID_REQUIRED',
+      });
     }
 
     try {
@@ -164,14 +180,20 @@ export class TriggerService {
 
       if (!trigger) {
         this.logger.warn('Trigger not found.');
-        throw new RpcException('Trigger not found.');
+        throw new RpcException({
+          message: 'Trigger not found.',
+          code: 'TRIGGER_NOT_FOUND',
+        });
       }
 
       if (trigger.isTriggered) {
         this.logger.warn(
           'Trigger has already been activated. Cannot update an activated trigger.',
         );
-        throw new RpcException('Trigger has already been activated.');
+        throw new RpcException({
+          message: 'Trigger has already been activated.',
+          code: 'TRIGGER_ALREADY_ACTIVATED',
+        });
       }
 
       // Validate source only if it's provided
@@ -179,9 +201,11 @@ export class TriggerService {
         this.logger.warn(
           `Invalid source value: ${dto.source}. Must be one of: ${Object.values(DataSource).join(', ')}`,
         );
-        throw new BadRequestException(
-          `Invalid source value. Must be one of: ${Object.values(DataSource).join(', ')}`,
-        );
+        throw new BadRequestException({
+          message: `Invalid source value. Must be one of: ${Object.values(DataSource).join(', ')}`,
+          code: 'INVALID_SOURCE_VALUE',
+          params: { list: Object.values(DataSource).join(', ') },
+        });
       }
 
       const fields = {
@@ -216,6 +240,7 @@ export class TriggerService {
       return updatedTrigger;
     } catch (error: any) {
       this.logger.error(error);
+      if (error instanceof RpcException) throw error;
       throw new RpcException(error.message);
     }
   }
@@ -263,6 +288,7 @@ export class TriggerService {
       );
     } catch (error: any) {
       this.logger.error(error);
+      if (error instanceof RpcException) throw error;
       throw new RpcException(error.message);
     }
   }
@@ -285,6 +311,7 @@ export class TriggerService {
       });
     } catch (error: any) {
       this.logger.error(error.message);
+      if (error instanceof RpcException) throw error;
       throw new RpcException(error.message);
     }
   }
@@ -297,7 +324,11 @@ export class TriggerService {
 
       if (!phase) {
         this.logger.error(`Phase with id: ${phaseId} not found.`);
-        throw new RpcException(`Phase with id: ${phaseId} not found.`);
+        throw new RpcException({
+          message: `Phase with id: ${phaseId} not found.`,
+          code: 'PHASE_NOT_FOUND',
+          params: { phaseId },
+        });
       }
 
       const payload = {
@@ -326,6 +357,7 @@ export class TriggerService {
       return trigger;
     } catch (error: any) {
       this.logger.error(error);
+      if (error instanceof RpcException) throw error;
       throw new RpcException(error.message);
     }
   }
@@ -336,7 +368,10 @@ export class TriggerService {
     this.logger.log(`Removing trigger with uuid: ${uuid}`);
 
     if (!uuid) {
-      throw new BadRequestException('Uuid is required');
+      throw new BadRequestException({
+        message: 'Uuid is required',
+        code: 'UUID_REQUIRED',
+      });
     }
 
     try {
@@ -350,21 +385,31 @@ export class TriggerService {
 
       if (!trigger) {
         this.logger.error(`Trigger with id: ${uuid} not found.`);
-        throw new RpcException(`Trigger with id: ${uuid} not found.`);
+        throw new RpcException({
+          message: `Trigger with id: ${uuid} not found.`,
+          code: 'TRIGGER_NOT_FOUND',
+          params: { uuid },
+        });
       }
 
       if (trigger.isTriggered) {
         this.logger.error(
           `Trigger with id: ${uuid} is activated. Cannot remove an activated trigger.`,
         );
-        throw new RpcException(`Cannot remove an activated trigger.`);
+        throw new RpcException({
+          message: 'Cannot remove an activated trigger.',
+          code: 'CANNOT_REMOVE_ACTIVATED_TRIGGER',
+        });
       }
 
       if (trigger.phase.isActive) {
         this.logger.error(
           `Trigger with id: ${uuid} is in an active phase. Cannot remove triggers from an active phase.`,
         );
-        throw new RpcException(`Cannot remove triggers from an active phase.`);
+        throw new RpcException({
+          message: 'Cannot remove triggers from an active phase.',
+          code: 'CANNOT_REMOVE_ACTIVE_PHASE_TRIGGERS',
+        });
       }
 
       const phaseDetail = await this.phasesService.findOne(trigger.phaseId);
@@ -376,7 +421,10 @@ export class TriggerService {
             phaseDetail.triggerRequirements.optionalTriggers.totalTriggers,
           ) - 1;
         if (totalTriggersAfterDeleting < phaseDetail.requiredOptionalTriggers) {
-          throw new RpcException(`Trigger criterias disrupted.`);
+          throw new RpcException({
+            message: 'Trigger criterias disrupted.',
+            code: 'TRIGGER_CRITERIA_DISRUPTED',
+          });
         }
       }
 
@@ -400,6 +448,7 @@ export class TriggerService {
       return updatedTrigger;
     } catch (error: any) {
       this.logger.error(error);
+      if (error instanceof RpcException) throw error;
       throw new RpcException(error.message);
     }
   }
@@ -516,6 +565,7 @@ export class TriggerService {
       }
     } catch (error: any) {
       this.logger.error(error);
+      if (error instanceof RpcException) throw error;
       throw new RpcException(error.message);
     }
   }
@@ -525,7 +575,10 @@ export class TriggerService {
     this.logger.log(`Activating trigger with uuid: ${uuid}`);
 
     if (!uuid) {
-      throw new BadRequestException('uuid is required');
+      throw new BadRequestException({
+        message: 'uuid is required',
+        code: 'UUID_REQUIRED',
+      });
     }
 
     try {
@@ -549,17 +602,26 @@ export class TriggerService {
 
       if (!trigger) {
         this.logger.warn('Trigger not found.');
-        throw new RpcException('Trigger not found.');
+        throw new RpcException({
+          message: 'Trigger not found.',
+          code: 'TRIGGER_NOT_FOUND',
+        });
       }
 
       if (trigger.isTriggered) {
         this.logger.warn('Trigger has already been activated.');
-        throw new RpcException('Trigger has already been activated.');
+        throw new RpcException({
+          message: 'Trigger has already been activated.',
+          code: 'TRIGGER_ALREADY_ACTIVATED',
+        });
       }
 
       if (trigger.source !== DataSource.MANUAL) {
         this.logger.warn('Cannot activate an automated trigger.');
-        throw new RpcException('Cannot activate an automated trigger.');
+        throw new RpcException({
+          message: 'Cannot activate an automated trigger.',
+          code: 'CANNOT_ACTIVATE_AUTOMATED_TRIGGER',
+        });
       }
 
       const triggerDocs = triggerDocuments?.length
@@ -662,6 +724,7 @@ export class TriggerService {
       return updatedTrigger;
     } catch (error: any) {
       this.logger.error(error);
+      if (error instanceof RpcException) throw error;
       throw new RpcException(error.message);
     }
   }
@@ -678,9 +741,11 @@ export class TriggerService {
 
       if (!trigger) {
         this.logger.warn(`Active trigger with id: ${repeatKey} not found.`);
-        throw new RpcException(
-          `Active trigger with id: ${repeatKey} not found.`,
-        );
+        throw new RpcException({
+          message: `Active trigger with id: ${repeatKey} not found.`,
+          code: 'ACTIVE_TRIGGER_NOT_FOUND',
+          params: { repeatKey },
+        });
       }
 
       const updatedTrigger = await this.prisma.trigger.update({
@@ -695,6 +760,7 @@ export class TriggerService {
       return updatedTrigger;
     } catch (error: any) {
       this.logger.error(error);
+      if (error instanceof RpcException) throw error;
       throw new RpcException(error.message);
     }
   }
@@ -745,6 +811,7 @@ export class TriggerService {
       // });
     } catch (error: any) {
       this.logger.error(error);
+      if (error instanceof RpcException) throw error;
       throw new RpcException(error.message);
     }
   }
@@ -956,6 +1023,7 @@ export class TriggerService {
       };
     } catch (error: any) {
       this.logger.warn('Error while generating phase triggers stats', error);
+      if (error instanceof RpcException) throw error;
       throw new RpcException(error);
     }
   }

--- a/apps/triggers/src/utils/all-exceptions.filter.ts
+++ b/apps/triggers/src/utils/all-exceptions.filter.ts
@@ -30,16 +30,29 @@ export class AllExceptionsFilter implements ExceptionFilter {
 
     if (exception instanceof RpcException) {
       const error = exception.getError();
-      message = typeof error === 'string' ? error : JSON.stringify(error);
-      errorDetails = typeof error === 'object' ? error : { message: error };
+      if (typeof error === 'string') {
+        message = error;
+        errorDetails = { message: error };
+      } else if (error && typeof error === 'object') {
+        // object form: new RpcException({ message, code, params })
+        message = (error as any).message ?? JSON.stringify(error);
+        errorDetails = error;
+      } else {
+        message = JSON.stringify(error);
+        errorDetails = { message };
+      }
     } else if (exception instanceof HttpException) {
       status = exception.getStatus();
       const exceptionResponse = exception.getResponse();
-      message =
-        typeof exceptionResponse === 'string'
-          ? exceptionResponse
-          : (exceptionResponse as any).message || message;
-      errorDetails = { statusCode: status, message };
+      if (typeof exceptionResponse === 'string') {
+        message = exceptionResponse;
+        errorDetails = { statusCode: status, message };
+      } else {
+        message = (exceptionResponse as any).message || message;
+        // preserve any extra fields (e.g. code, params) set via
+        // new BadRequestException({ message, code, params })
+        errorDetails = { statusCode: status, ...(exceptionResponse as any) };
+      }
     } else if (exception instanceof Error) {
       message = exception.message;
       errorDetails = {
@@ -58,6 +71,8 @@ export class AllExceptionsFilter implements ExceptionFilter {
       statusCode: status,
       timestamp: new Date().toISOString(),
       message,
+      code: (errorDetails as any)?.code,
+      params: (errorDetails as any)?.params,
       error: errorDetails,
     }));
   }
@@ -69,14 +84,19 @@ export class AllExceptionsFilter implements ExceptionFilter {
 
     let status = HttpStatus.INTERNAL_SERVER_ERROR;
     let message = 'Internal server error';
+    let code: string | undefined;
+    let params: Record<string, unknown> | undefined;
 
     if (exception instanceof HttpException) {
       status = exception.getStatus();
       const exceptionResponse = exception.getResponse();
-      message =
-        typeof exceptionResponse === 'string'
-          ? exceptionResponse
-          : (exceptionResponse as any).message || message;
+      if (typeof exceptionResponse === 'string') {
+        message = exceptionResponse;
+      } else {
+        message = (exceptionResponse as any).message || message;
+        code = (exceptionResponse as any).code;
+        params = (exceptionResponse as any).params;
+      }
     } else if (exception instanceof Error) {
       message = exception.message;
     }
@@ -91,6 +111,8 @@ export class AllExceptionsFilter implements ExceptionFilter {
       timestamp: new Date().toISOString(),
       path: request.url,
       message,
+      code,
+      params,
     });
   }
 }


### PR DESCRIPTION
**What changed**

- Extended the shared HTTP and RPC exception filter to forward an optional error code and parameter set from an exception's payload through to the response, for both the microservice error-response shape and the REST error-response shape this service exposes. This is additive only — no existing response field, status code, or error-handling flow was altered.
- Converted error throws across trigger evaluation, phase transitions, activity management, trigger history, data-source ingestion, and communications from free-text-only exceptions to ones carrying a stable identifier alongside the existing English message.
- Added structured parameters for messages that interpolate a runtime value, so a localized template can place the value correctly instead of inheriting an English sentence fragment.


**Approach**

- Code, not text, is the translation key. Each converted error now carries a stable identifier alongside its existing English message, so the message keeps working unchanged for any consumer not going through translation, while the frontend can key a localized lookup off the identifier when present.
- Structured parameters for dynamic values. Runtime values are passed as separate parameters rather than baked into the English sentence, preserving correct word order and grammar once localized.
- Scoped strictly to reachability. Only error sites confirmed reachable from a live, in-scope UI flow were converted. Paths that only surface on technical/admin-only views or are dead/unreferenced were deliberately left untouched.
- No behavior change for existing consumers. Every conversion preserves the original status code and English message text exactly; the identifier and parameters are additive fields only. Nothing about when or how an error is thrown changed.
- 